### PR TITLE
FIX: wrong source for integral computation

### DIFF
--- a/panTompkins.c
+++ b/panTompkins.c
@@ -348,7 +348,7 @@ void panTompkins()
 		for (i = 0; i < WINDOWSIZE; i++)
 		{
 			if (current >= (dataType)i)
-				integral[current] += highpass[current - i];
+				integral[current] += squared[current - i];
 			else
 				break;
 		}


### PR DESCRIPTION
The integrated signal should be computed using the squared derivative instead of the highpass signal.
Using the highpass signal still results in a decent peak detection, but using the squared signal is what is proposed in the PanTompkins algorithm and is a lot more robust