### PR TITLE
Fix compilation error

### DIFF
--- a/panTompkins.h
+++ b/panTompkins.h
@@ -37,6 +37,6 @@ typedef int dataType;
 typedef enum {false, true} bool;
 
 void panTompkins();
-void init(char file_in[], char file_out[]);
+void init(const char file_in[], const char file_out[]);
 
 #endif


### PR DESCRIPTION
```
panTompkins.c:176:6: error: conflicting types for ‘init’; have ‘void(const char *, const char *)’
  176 | void init(const char file_in[], const char file_out[])
      |      ^~~~
In file included from panTompkins.c:164:
panTompkins.h:40:6: note: previous declaration of ‘init’ with type ‘void(char *, char *)’
   40 | void init(char file_in[], char file_out[]);
      |      ^~~~
``` 